### PR TITLE
TE-1234: bump version to v25.7.1 and add version support

### DIFF
--- a/examples/example_version.go
+++ b/examples/example_version.go
@@ -1,0 +1,18 @@
+/*
+Graphiant Go SDK Example
+
+This example demonstrates how to access the SDK version.
+
+*/
+
+package main
+
+import (
+	"fmt"
+
+	graphiant_sdk "github.com/Graphiant-Inc/graphiant-sdk-go"
+)
+
+func main() {
+	fmt.Printf("Graphiant Go SDK Version: %s\n", graphiant_sdk.Version)
+}

--- a/test/version_test.go
+++ b/test/version_test.go
@@ -1,0 +1,21 @@
+/*
+Graphiant Go SDK
+
+Testing Version constant
+
+*/
+
+package graphiant_sdk
+
+import (
+	"testing"
+
+	openapiclient "github.com/Graphiant-Inc/graphiant-sdk-go"
+)
+
+func TestVersion(t *testing.T) {
+	expectedVersion := "v25.7.1"
+	if openapiclient.Version != expectedVersion {
+		t.Errorf("Expected version %s, got %s", expectedVersion, openapiclient.Version)
+	}
+}

--- a/version.go
+++ b/version.go
@@ -1,0 +1,12 @@
+/*
+Graphiant Go SDK
+
+Graphiant API Go SDK.
+
+SDK version: v25.7.1
+*/
+
+package graphiant_sdk
+
+// Version is the current version of the Graphiant Go SDK
+const Version = "v25.7.1"


### PR DESCRIPTION
- Add version.go with SDK version constant
- Add version test to verify version functionality
- Add example demonstrating version usage
- Update README with version information