### PR TITLE
Potential fix for code scanning alert no. 3: Clear-text logging of sensitive information

### DIFF
--- a/api_custom.go
+++ b/api_custom.go
@@ -31,8 +31,7 @@ func GetDeviceStatus(apiClient *APIClient, token string, deviceId int64) bool {
 
 func PutDeviceConfig(apiClient *APIClient, token string, deviceId int64, deviceConfig V1DevicesDeviceIdConfigPutRequest) *http.Response {
 
-	configJSON, _ := json.MarshalIndent(deviceConfig, "", "  ")
-	fmt.Printf("Executing config put request for device %d...\nConfig: %s\n", deviceId, string(configJSON))
+	fmt.Printf("Executing config put request for device %d...\n", deviceId)
 
 	_, httpRes, err := apiClient.DefaultAPI.
 		V1DevicesDeviceIdConfigPut(context.Background(), deviceId).
@@ -41,15 +40,17 @@ func PutDeviceConfig(apiClient *APIClient, token string, deviceId int64, deviceC
 
 	if err != nil {
 		if httpRes != nil {
-			body, _ := io.ReadAll(httpRes.Body)
-			fmt.Printf("Error executing config put request: %v\nHTTP Status: %d\nResponse Body: %s\n", err, httpRes.StatusCode, string(body))
+			// Drain and discard response body to avoid logging potentially sensitive data.
+			_, _ = io.ReadAll(httpRes.Body)
+			fmt.Printf("Error executing config put request for device %d: %v (HTTP Status: %d)\n", deviceId, err, httpRes.StatusCode)
 		} else {
-			fmt.Printf("Error executing config put request: %v\n", err)
+			fmt.Printf("Error executing config put request for device %d: %v\n", deviceId, err)
 		}
 		return nil
 	}
-	body, _ := io.ReadAll(httpRes.Body)
-	fmt.Printf("Config put response: %s, http status: %v\n", string(body), httpRes.StatusCode)
+	// Read and discard response body without logging its potentially sensitive contents.
+	_, _ = io.ReadAll(httpRes.Body)
+	fmt.Printf("Config put request for device %d completed successfully with HTTP status: %v\n", deviceId, httpRes.StatusCode)
 	return httpRes
 
 }


### PR DESCRIPTION
Potential fix for [https://github.com/Graphiant-Inc/graphiant-sdk-go/security/code-scanning/3](https://github.com/Graphiant-Inc/graphiant-sdk-go/security/code-scanning/3)

In general, to fix clear-text logging of sensitive information you should avoid logging raw configuration objects, request/response bodies, and error values that may embed secrets. Instead, log only non-sensitive metadata (IDs, statuses, counts) or explicitly scrub/obfuscate known-sensitive fields before logging.

For this codebase, the best minimal fix without changing functionality is to:
- Stop printing the entire JSON representation of `deviceConfig`.
- Stop printing the full HTTP response body on both error and success.
- Keep logging high-level information: device ID and HTTP status code, maybe a generic error message.
- Leave all request/response behavior untouched.

These changes are all localized to `api_custom.go`:

1. In `PutDeviceConfig`, remove or reduce the logging of `configJSON`. You can either delete the `configJSON` creation entirely or keep it but not log its contents; the simplest is to log only the device ID and maybe the fact that a config PUT is being executed.
2. In the error-handling branch, avoid logging the raw `body`. You can still read the body to ensure it is drained, but either omit it from logs or replace it with a generic message, e.g., “response body omitted for security”.
3. In the success path, similarly avoid logging the raw response body; log only the HTTP status code.

No other files need modification: the data flow through the generated model and client code is fine; the vulnerability arises only because the custom helper logs everything.

Concretely:
- Edit `api_custom.go` lines 34–36 to stop printing `Config: %s\n` with the entire JSON.
- Edit lines 44–46 to avoid including `string(body)` in the `fmt.Printf`.
- Edit lines 51–52 to avoid including `string(body)` in the `fmt.Printf`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
