### PR TITLE
Potential fix for code scanning alert no. 2: Clear-text logging of sensitive information

### DIFF
--- a/api_custom.go
+++ b/api_custom.go
@@ -31,8 +31,8 @@ func GetDeviceStatus(apiClient *APIClient, token string, deviceId int64) bool {
 
 func PutDeviceConfig(apiClient *APIClient, token string, deviceId int64, deviceConfig V1DevicesDeviceIdConfigPutRequest) *http.Response {
 
-	configJSON, _ := json.MarshalIndent(deviceConfig, "", "  ")
-	fmt.Printf("Executing config put request for device %d...\nConfig: %s\n", deviceId, string(configJSON))
+	// Do not log full device configuration to avoid exposing sensitive data.
+	fmt.Printf("Executing config put request for device %d...\n", deviceId)
 
 	_, httpRes, err := apiClient.DefaultAPI.
 		V1DevicesDeviceIdConfigPut(context.Background(), deviceId).
@@ -41,15 +41,17 @@ func PutDeviceConfig(apiClient *APIClient, token string, deviceId int64, deviceC
 
 	if err != nil {
 		if httpRes != nil {
-			body, _ := io.ReadAll(httpRes.Body)
-			fmt.Printf("Error executing config put request: %v\nHTTP Status: %d\nResponse Body: %s\n", err, httpRes.StatusCode, string(body))
+			// Read and discard the body if needed, but do not log it to avoid leaking sensitive data.
+			_, _ = io.ReadAll(httpRes.Body)
+			fmt.Printf("Error executing config put request for device %d: http status %d\n", deviceId, httpRes.StatusCode)
 		} else {
-			fmt.Printf("Error executing config put request: %v\n", err)
+			fmt.Printf("Error executing config put request for device %d\n", deviceId)
 		}
 		return nil
 	}
-	body, _ := io.ReadAll(httpRes.Body)
-	fmt.Printf("Config put response: %s, http status: %v\n", string(body), httpRes.StatusCode)
+	// Read and discard the response body; avoid logging potential sensitive data.
+	_, _ = io.ReadAll(httpRes.Body)
+	fmt.Printf("Config put request for device %d succeeded, http status: %v\n", deviceId, httpRes.StatusCode)
 	return httpRes
 
 }


### PR DESCRIPTION
Potential fix for [https://github.com/Graphiant-Inc/graphiant-sdk-go/security/code-scanning/2](https://github.com/Graphiant-Inc/graphiant-sdk-go/security/code-scanning/2)

General approach: Avoid logging raw configuration bodies and HTTP responses that may contain secrets, and avoid logging low-level error objects if they may embed serialized request content or other sensitive context. Instead, log only non-sensitive metadata (device ID, HTTP status code, high-level error message) and, if needed, redact or omit fields that can contain credentials.

Best concrete fix here: Update `PutDeviceConfig` in `api_custom.go` to (1) stop logging the full JSON serialization of `deviceConfig`, and (2) stop logging the full HTTP response body on error and success. For debugging, we can still log the device ID and status code, and possibly the length of the body, but not the body content itself. We can also log `err` in a generic way without including potentially tainted context. This single change in `api_custom.go` breaks the taint flow from any sensitive fields inside `deviceConfig` or the response into the logging sink, addressing all the alert variants tied to this call pattern.

Specific changes (all in `api_custom.go`):

- Remove or change line 35 so that it no longer includes `config: %s\n` with the full `configJSON`. An acceptable replacement is a message like `Executing config put request for device %d...\n` that omits the config details entirely.
- In the error-handling block:
  - Replace `fmt.Printf("Error executing config put request: %v\nHTTP Status: %d\nResponse Body: %s\n", err, httpRes.StatusCode, string(body))` with a version that does not output `body` and does not print the raw `err` if it could contain sensitive details. For example: `fmt.Printf("Error executing config put request for device %d: http status %d\n", deviceId, httpRes.StatusCode)`. If retaining some error information is important, keep only `err.Error()` but do not add body content.
- In the success path:
  - Replace `fmt.Printf("Config put response: %s, http status: %v\n", string(body), httpRes.StatusCode)` with a log line that omits `body`, such as `fmt.Printf("Config put request for device %d succeeded, http status: %v\n", deviceId, httpRes.StatusCode)`.

No changes to imports are strictly required (we can keep `encoding/json` even if `configJSON` is no longer used, but it’s harmless; if you want to clean it, you could remove the variable and keep the import since other parts might use it elsewhere—outside the provided snippet we must not assume).

This preserves existing functionality (the HTTP behavior is unchanged) and only reduces the verbosity of logging so that secrets are no longer printed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
