### PR TITLE
Potential fix for code scanning alert no. 9: Clear-text logging of sensitive information

### DIFF
--- a/api_custom.go
+++ b/api_custom.go
@@ -41,9 +41,9 @@ func PutDeviceConfig(apiClient *APIClient, token string, deviceId int64, deviceC
 		if httpRes != nil {
 			// Drain and discard response body to avoid logging potentially sensitive data.
 			_, _ = io.ReadAll(httpRes.Body)
-			fmt.Printf("Error executing config put request for device %d: %v (HTTP Status: %d)\n", deviceId, err, httpRes.StatusCode)
+			fmt.Printf("Error executing config put request for device %d (HTTP Status: %d). Error details omitted from log.\n", deviceId, httpRes.StatusCode)
 		} else {
-			fmt.Printf("Error executing config put request for device %d: %v\n", deviceId, err)
+			fmt.Printf("Error executing config put request for device %d. Error details omitted from log.\n", deviceId)
 		}
 		return nil
 	}


### PR DESCRIPTION
Potential fix for [https://github.com/Graphiant-Inc/graphiant-sdk-go/security/code-scanning/9](https://github.com/Graphiant-Inc/graphiant-sdk-go/security/code-scanning/9)

General approach: Avoid logging raw `error` values that may embed or derive from sensitive request data (headers/body) when dealing with configuration updates that contain secrets. Instead, log only high-level context (device id, that an error occurred, HTTP status code) and either omit the error text entirely or replace it with a generic message. This addresses all alert variants because they all flow through the same `err` variable in `PutDeviceConfig`.

Best concrete fix: In `api_custom.go`, in `PutDeviceConfig`, change the two `fmt.Printf` calls inside the `if err != nil` block so they no longer include `%v` with the `err` argument. Keep logging the device id and HTTP status code (which are non-sensitive), and add a generic placeholder like “see client logs” if desired. Do not alter how the API call is made or how the response body is drained; that preserves existing behavior.

Specific changes:

- File: `api_custom.go`
  - In `PutDeviceConfig`, lines 44 and 46 (per snippet), replace:
    - `fmt.Printf("Error executing config put request for device %d: %v (HTTP Status: %d)\n", deviceId, err, httpRes.StatusCode)`
    - `fmt.Printf("Error executing config put request for device %d: %v\n", deviceId, err)`
  - With versions that omit `err`, for example:
    - `fmt.Printf("Error executing config put request for device %d (HTTP Status: %d). Error details omitted from log.\n", deviceId, httpRes.StatusCode)`
    - `fmt.Printf("Error executing config put request for device %d. Error details omitted from log.\n", deviceId)`
- No new methods or imports are needed; we only adjust the format strings and arguments.

This single change ensures that even if `err` contains data derived from secret fields (as CodeQL suggests via `BgpAuthKey`, passwords, API keys, etc.), that data will no longer be written to logs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
