### PR TITLE
Potential fix for code scanning alert no. 8: Clear-text logging of sensitive information

### DIFF
--- a/api_custom.go
+++ b/api_custom.go
@@ -41,9 +41,9 @@ func PutDeviceConfig(apiClient *APIClient, token string, deviceId int64, deviceC
 		if httpRes != nil {
 			// Drain and discard response body to avoid logging potentially sensitive data.
 			_, _ = io.ReadAll(httpRes.Body)
-			fmt.Printf("Error executing config put request for device %d: %v (HTTP Status: %d)\n", deviceId, err, httpRes.StatusCode)
+			fmt.Printf("Error executing config put request for device %d (HTTP Status: %d). See upstream logs for details.\n", deviceId, httpRes.StatusCode)
 		} else {
-			fmt.Printf("Error executing config put request for device %d: %v\n", deviceId, err)
+			fmt.Printf("Error executing config put request for device %d. See upstream logs for details.\n", deviceId)
 		}
 		return nil
 	}


### PR DESCRIPTION
Potential fix for [https://github.com/Graphiant-Inc/graphiant-sdk-go/security/code-scanning/8](https://github.com/Graphiant-Inc/graphiant-sdk-go/security/code-scanning/8)

General approach: avoid logging values that may contain or derive from sensitive data. In this case, the problematic sink is `fmt.Printf(... %v, err, ...)` in `PutDeviceConfig`. We should still report that an error occurred and, if safe, include non-sensitive metadata like device ID and HTTP status code, but not the raw `error` string when that error might embed request details built from configuration objects containing secrets.

Best concrete fix: change the two `fmt.Printf` calls in `PutDeviceConfig` that interpolate `err` to omit the error details (or replace them with a generic placeholder), while keeping the rest of the function’s behavior intact. We do not need to modify how requests are built or how bodies are marshaled; we just need to ensure the log message doesn’t directly include the tainted `error`. To preserve some debugging value, we can log that an error occurred and suggest checking higher-level logs or return the error to the caller via a different mechanism, but per the constraints we won’t change the function signature, so we’ll just keep returning `nil` on error as it currently does.

Concretely, in `api_custom.go`:

- Replace

  ```go
  fmt.Printf("Error executing config put request for device %d: %v (HTTP Status: %d)\n", deviceId, err, httpRes.StatusCode)
  ```

  with a version that doesn’t format `err`, e.g.:

  ```go
  fmt.Printf("Error executing config put request for device %d (HTTP Status: %d). See upstream logs for details.\n", deviceId, httpRes.StatusCode)
  ```

- Replace

  ```go
  fmt.Printf("Error executing config put request for device %d: %v\n", deviceId, err)
  ```

  with:

  ```go
  fmt.Printf("Error executing config put request for device %d. See upstream logs for details.\n", deviceId)
  ```

No new imports or helper methods are required; we only adjust string literals and argument lists. This single change ensures that, regardless of how the `error` was constructed (`setBody`, `prepareRequest`, HTTP client, etc.), its possibly sensitive contents are not written to logs, addressing all the variants that trace taint into this logging call.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
