### PR TITLE
Potential fix for code scanning alert no. 1: Clear-text logging of sensitive information

### DIFF
--- a/client.go
+++ b/client.go
@@ -244,14 +244,59 @@ func parameterToJson(obj interface{}) (string, error) {
 	return string(jsonBuf), err
 }
 
+// debugLogRequest logs basic request information without logging the body.
+func debugLogRequest(req *http.Request) {
+	if req == nil {
+		return
+	}
+	var b strings.Builder
+	// Request line
+	fmt.Fprintf(&b, "%s %s %s\n", req.Method, req.URL.String(), req.Proto)
+	// Headers (with basic redaction for sensitive ones)
+	for name, values := range req.Header {
+		lowerName := strings.ToLower(name)
+		if lowerName == "authorization" || lowerName == "proxy-authorization" {
+			fmt.Fprintf(&b, "%s: %s\n", name, "***REDACTED***")
+			continue
+		}
+		for _, v := range values {
+			fmt.Fprintf(&b, "%s: %s\n", name, v)
+		}
+	}
+	log.Printf("\n%s\n", b.String())
+}
+
+// debugLogResponse logs basic response information without logging the body.
+func debugLogResponse(resp *http.Response) {
+	if resp == nil {
+		return
+	}
+	var b strings.Builder
+	// Status line
+	urlStr := ""
+	if resp.Request != nil && resp.Request.URL != nil {
+		urlStr = resp.Request.URL.String()
+	}
+	fmt.Fprintf(&b, "%s %s\n", resp.Status, urlStr)
+	// Headers (with basic redaction for sensitive ones)
+	for name, values := range resp.Header {
+		lowerName := strings.ToLower(name)
+		if lowerName == "set-cookie" {
+			// Cookies may contain sensitive data; redact entire header.
+			fmt.Fprintf(&b, "%s: %s\n", name, "***REDACTED***")
+			continue
+		}
+		for _, v := range values {
+			fmt.Fprintf(&b, "%s: %s\n", name, v)
+		}
+	}
+	log.Printf("\n%s\n", b.String())
+}
+
 // callAPI do the request.
 func (c *APIClient) callAPI(request *http.Request) (*http.Response, error) {
 	if c.cfg.Debug {
-		dump, err := httputil.DumpRequestOut(request, true)
-		if err != nil {
-			return nil, err
-		}
-		log.Printf("\n%s\n", string(dump))
+		debugLogRequest(request)
 	}
 
 	resp, err := c.cfg.HTTPClient.Do(request)
@@ -260,11 +305,7 @@ func (c *APIClient) callAPI(request *http.Request) (*http.Response, error) {
 	}
 
 	if c.cfg.Debug {
-		dump, err := httputil.DumpResponse(resp, true)
-		if err != nil {
-			return resp, err
-		}
-		log.Printf("\n%s\n", string(dump))
+		debugLogResponse(resp)
 	}
 	return resp, err
 }


### PR DESCRIPTION
Potential fix for [https://github.com/Graphiant-Inc/graphiant-sdk-go/security/code-scanning/1](https://github.com/Graphiant-Inc/graphiant-sdk-go/security/code-scanning/1)

In general, the problem is that `callAPI` logs complete HTTP requests and responses including bodies, which may contain secrets. The safest fix is to avoid logging bodies altogether, or at least to scrub them before logging, while still allowing useful debug information such as method, URL, and non-sensitive headers.

The best minimal-impact change is to replace the use of `httputil.DumpRequestOut` and `httputil.DumpResponse` (with `body=true`) with a custom debug logging helper that logs only the request/response line and headers, and truncates or omits the body entirely. This preserves debugging functionality without exposing sensitive content. We can implement two helper functions in `client.go`:

- `debugLogRequest(req *http.Request)` – constructs a string containing the HTTP method, URL, and headers (optionally redacting obviously sensitive headers like `Authorization`) and logs it.
- `debugLogResponse(resp *http.Response)` – similarly logs status, URL, and headers, but not the body.

Then, in `callAPI`, we replace the `DumpRequestOut`/`DumpResponse` calls with calls to these helpers. This change is localized to `client.go` (where the unsafe logging occurs). We do not need to modify the model files; they remain as-is, and the tainted data will no longer reach a logging sink because bodies aren’t logged.

Concretely:

- In `client.go`, add new helper functions (just above `callAPI` to keep generated structure intact but localized).
- In `callAPI`, remove the `httputil.DumpRequestOut`/`DumpResponse` usage and instead call the new helpers when `c.cfg.Debug` is true.
- Keep existing imports; we already import `fmt`, `log`, `net/http`, etc., so no new dependencies are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
